### PR TITLE
Fix error: filename is not defined

### DIFF
--- a/appengine-malwarescanningservice-node/app.yaml
+++ b/appengine-malwarescanningservice-node/app.yaml
@@ -33,5 +33,5 @@ automatic_scaling:
   max_num_instances: 2
 resources:
   cpu: 1
-  memory_gb: 2
+  memory_gb: 4
   disk_size_gb: 10

--- a/appengine-malwarescanningservice-node/server.js
+++ b/appengine-malwarescanningservice-node/server.js
@@ -48,9 +48,8 @@ const run = () => app.listen(PORT, () => {
  */
 app.post('/scan', async (req, res) => {
   console.log('Request body', req.body);
+  let filename = req.body.filename;
   try {
-    let filename = req.body.filename;
-
     const options = {
       destination: `/unscanned_files/${filename}`
     };


### PR DESCRIPTION
Fix for issue #1 

The invocation of deleteLocalCopy() would fail with the following error, and thus would fail to delete the local file.

(node:1379) UnhandledPromiseRejectionWarning: ReferenceError: filename is not defined
    at app.post (/app/server.js:97:41)
    at process._tickCallback (internal/process/next_tick.js:68:7)