### PR TITLE
Fix clamd killed OOM

### DIFF
--- a/appengine-malwarescanningservice-node/app.yaml
+++ b/appengine-malwarescanningservice-node/app.yaml
@@ -33,5 +33,5 @@ automatic_scaling:
   max_num_instances: 2
 resources:
   cpu: 1
-  memory_gb: 2
+  memory_gb: 4
   disk_size_gb: 10


### PR DESCRIPTION
As in issue #3 recently the `appengine-malwarescanningservice-node` app engine does not come up properly with "`Error: connect ECONNREFUSED 127.0.0.1:3310`". Further triaging shows the `clamd` process in the docker was killed OOM. A potential cause is a growing size of the anti-virus database. Increasing the memory size of the docker deployment fixed the problem.
