### PR TITLE
[NVCP-311] Migrate from Eventarc to Cloud Pub/Sub

### DIFF
--- a/cloudrun-malware-scanner/config.json
+++ b/cloudrun-malware-scanner/config.json
@@ -15,5 +15,6 @@
       "clean": "ds4g-document-management-scanned",
       "quarantined": "ds4g-document-management-quarantine"
     }
-  ]
+  ],
+  "upload_topic": "projects/ny-dol-wp-work-manager/topics/NEW_FILE_UPLOADED"
 }

--- a/cloudrun-malware-scanner/config.json
+++ b/cloudrun-malware-scanner/config.json
@@ -11,9 +11,9 @@
   ],
   "buckets": [
     {
-      "unscanned": "unscanned-bucket-name",
-      "clean": "clean-bucket-name",
-      "quarantined": "quarantined-bucket-name"
+      "unscanned": "ds4g-document-management-unscanned",
+      "clean": "ds4g-document-management-scanned",
+      "quarantined": "ds4g-document-management-quarantine"
     }
   ]
 }

--- a/cloudrun-malware-scanner/package-lock.json
+++ b/cloudrun-malware-scanner/package-lock.json
@@ -12,6 +12,7 @@
         "@google-cloud/common": "^3.10.0",
         "@google-cloud/logging-bunyan": "^3.2.0",
         "@google-cloud/monitoring": "^2.3.5",
+        "@google-cloud/pubsub": "^3.0.1",
         "@google-cloud/storage": "^5.18.2",
         "@opencensus/core": "^0.1.0",
         "@opencensus/exporter-stackdriver": "^0.1.0",
@@ -138,6 +139,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-2.0.4.tgz",
+      "integrity": "sha512-nOB+mZdevI/1Si0QAfxWfzzIqFdc7wrO+DYePFvgbOoMtvX+XfFTINNt7e9Zg66AbDbWCPRnikU+6f5LTm9Wyg==",
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
     "node_modules/@google-cloud/projectify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.1.tgz",
@@ -152,6 +161,157 @@
       "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@google-cloud/pubsub": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-3.0.1.tgz",
+      "integrity": "sha512-dznNbRd/Y8J0C0xvdvCPi3B1msK/dj/Nya+NQZ2doUOLT6eoa261tBwk9umOQs5L5GKcdlqQKbBjrNjDYVbzQA==",
+      "dependencies": {
+        "@google-cloud/paginator": "^4.0.0",
+        "@google-cloud/precise-date": "^2.0.0",
+        "@google-cloud/projectify": "^2.0.0",
+        "@google-cloud/promisify": "^2.0.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@types/duplexify": "^3.6.0",
+        "@types/long": "^4.0.0",
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^8.0.2",
+        "google-gax": "^3.0.1",
+        "is-stream-ended": "^0.1.4",
+        "lodash.snakecase": "^4.1.1",
+        "p-defer": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/@google-cloud/paginator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-4.0.0.tgz",
+      "integrity": "sha512-wNmCZl+2G2DmgT/VlF+AROf80SoaC/CwS8trwmjNaq26VRNK8yPbU5F/Vy+R9oDAGKWQU2k8+Op5H4kFJVXFaQ==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/gaxios": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.0.tgz",
+      "integrity": "sha512-VD/yc5ln6XU8Ch1hyYY6kRMBE0Yc2np3fPyeJeYHhrPs1i8rgnsApPMWyrugkl7LLoSqpOJVBWlQIa87OAvt8Q==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/gcp-metadata": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
+      "integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/google-auth-library": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.0.2.tgz",
+      "integrity": "sha512-HoG+nWFAThLovKpvcbYzxgn+nBJPTfAwtq0GxPN821nOO+21+8oP7MoEHfd1sbDulUFFGfcjJr2CnJ4YssHcyg==",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^5.0.0",
+        "gcp-metadata": "^5.0.0",
+        "gtoken": "^5.3.2",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/google-gax": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.1.1.tgz",
+      "integrity": "sha512-lLiv6s3Ax5i0Iqy/crHrIZuaU1AYZvTj/F8DCcdJvmDWDsFSVSh+KkCEkKGd7PHck3dVB58NnbC4FIiRpTq4WQ==",
+      "dependencies": {
+        "@grpc/grpc-js": "~1.6.0",
+        "@grpc/proto-loader": "^0.6.12",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "fast-text-encoding": "^1.0.3",
+        "google-auth-library": "^8.0.2",
+        "is-stream-ended": "^0.1.4",
+        "node-fetch": "^2.6.1",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^1.0.0",
+        "protobufjs": "6.11.3",
+        "retry-request": "^5.0.0"
+      },
+      "bin": {
+        "compileProtos": "build/tools/compileProtos.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/proto3-json-serializer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.0.1.tgz",
+      "integrity": "sha512-jtnGKL8EE1mTOl2qgMZJQXbS22dlb2K07i4b5vp8yMGMJ6mFSgBg4Ossu/g9NCuamdYXHjp3XxyWw4tJ0G/uKw==",
+      "dependencies": {
+        "protobufjs": "^6.11.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@google-cloud/pubsub/node_modules/retry-request": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.0.tgz",
+      "integrity": "sha512-vBZdBxUordje9253imlmGtppC5gdcwZmNz7JnU2ui+KKFPk25keR+0c020AVV20oesYxIFOI0Kh3HE88/59ieg==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@google-cloud/storage": {
@@ -296,6 +456,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA==",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -356,6 +532,14 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@types/duplexify": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.1.tgz",
+      "integrity": "sha512-n0zoEj/fMdMOvqbHxmqnza/kXyoGgJmEpsXjpP+gEqE1Ye4yNqc7xWipKnUoMpWhMuzJQSfK2gMrwlElly7OGQ==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/long": {
@@ -1614,12 +1798,12 @@
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "node_modules/gtoken": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.1.tgz",
-      "integrity": "sha512-yqOREjzLHcbzz1UrQoxhBtpk8KjrVhuqPE7od1K2uhyxG2BHjKZetlbLw/SPZak/QqTIQW+addS+EcjqQsZbwQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
+      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
       "dependencies": {
         "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.0.3",
+        "google-p12-pem": "^3.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
@@ -1885,6 +2069,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
     "node_modules/log-driver": {
       "version": "1.2.7",
@@ -2183,6 +2372,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -3066,6 +3263,11 @@
         "extend": "^3.0.2"
       }
     },
+    "@google-cloud/precise-date": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-2.0.4.tgz",
+      "integrity": "sha512-nOB+mZdevI/1Si0QAfxWfzzIqFdc7wrO+DYePFvgbOoMtvX+XfFTINNt7e9Zg66AbDbWCPRnikU+6f5LTm9Wyg=="
+    },
     "@google-cloud/projectify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.1.tgz",
@@ -3075,6 +3277,121 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz",
       "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA=="
+    },
+    "@google-cloud/pubsub": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-3.0.1.tgz",
+      "integrity": "sha512-dznNbRd/Y8J0C0xvdvCPi3B1msK/dj/Nya+NQZ2doUOLT6eoa261tBwk9umOQs5L5GKcdlqQKbBjrNjDYVbzQA==",
+      "requires": {
+        "@google-cloud/paginator": "^4.0.0",
+        "@google-cloud/precise-date": "^2.0.0",
+        "@google-cloud/projectify": "^2.0.0",
+        "@google-cloud/promisify": "^2.0.0",
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@types/duplexify": "^3.6.0",
+        "@types/long": "^4.0.0",
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^8.0.2",
+        "google-gax": "^3.0.1",
+        "is-stream-ended": "^0.1.4",
+        "lodash.snakecase": "^4.1.1",
+        "p-defer": "^3.0.0"
+      },
+      "dependencies": {
+        "@google-cloud/paginator": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-4.0.0.tgz",
+          "integrity": "sha512-wNmCZl+2G2DmgT/VlF+AROf80SoaC/CwS8trwmjNaq26VRNK8yPbU5F/Vy+R9oDAGKWQU2k8+Op5H4kFJVXFaQ==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "extend": "^3.0.2"
+          }
+        },
+        "gaxios": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.0.0.tgz",
+          "integrity": "sha512-VD/yc5ln6XU8Ch1hyYY6kRMBE0Yc2np3fPyeJeYHhrPs1i8rgnsApPMWyrugkl7LLoSqpOJVBWlQIa87OAvt8Q==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.6.7"
+          }
+        },
+        "gcp-metadata": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.0.0.tgz",
+          "integrity": "sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==",
+          "requires": {
+            "gaxios": "^5.0.0",
+            "json-bigint": "^1.0.0"
+          }
+        },
+        "google-auth-library": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.0.2.tgz",
+          "integrity": "sha512-HoG+nWFAThLovKpvcbYzxgn+nBJPTfAwtq0GxPN821nOO+21+8oP7MoEHfd1sbDulUFFGfcjJr2CnJ4YssHcyg==",
+          "requires": {
+            "arrify": "^2.0.0",
+            "base64-js": "^1.3.0",
+            "ecdsa-sig-formatter": "^1.0.11",
+            "fast-text-encoding": "^1.0.0",
+            "gaxios": "^5.0.0",
+            "gcp-metadata": "^5.0.0",
+            "gtoken": "^5.3.2",
+            "jws": "^4.0.0",
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "google-gax": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.1.1.tgz",
+          "integrity": "sha512-lLiv6s3Ax5i0Iqy/crHrIZuaU1AYZvTj/F8DCcdJvmDWDsFSVSh+KkCEkKGd7PHck3dVB58NnbC4FIiRpTq4WQ==",
+          "requires": {
+            "@grpc/grpc-js": "~1.6.0",
+            "@grpc/proto-loader": "^0.6.12",
+            "@types/long": "^4.0.0",
+            "abort-controller": "^3.0.0",
+            "duplexify": "^4.0.0",
+            "fast-text-encoding": "^1.0.3",
+            "google-auth-library": "^8.0.2",
+            "is-stream-ended": "^0.1.4",
+            "node-fetch": "^2.6.1",
+            "object-hash": "^3.0.0",
+            "proto3-json-serializer": "^1.0.0",
+            "protobufjs": "6.11.3",
+            "retry-request": "^5.0.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "proto3-json-serializer": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.0.1.tgz",
+          "integrity": "sha512-jtnGKL8EE1mTOl2qgMZJQXbS22dlb2K07i4b5vp8yMGMJ6mFSgBg4Ossu/g9NCuamdYXHjp3XxyWw4tJ0G/uKw==",
+          "requires": {
+            "protobufjs": "^6.11.3"
+          }
+        },
+        "retry-request": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.0.tgz",
+          "integrity": "sha512-vBZdBxUordje9253imlmGtppC5gdcwZmNz7JnU2ui+KKFPk25keR+0c020AVV20oesYxIFOI0Kh3HE88/59ieg==",
+          "requires": {
+            "debug": "^4.1.1",
+            "extend": "^3.0.2"
+          }
+        }
+      }
     },
     "@google-cloud/storage": {
       "version": "5.18.2",
@@ -3193,6 +3510,16 @@
         "gcp-metadata": "^4.3.0"
       }
     },
+    "@opentelemetry/api": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
+      "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
+    },
+    "@opentelemetry/semantic-conventions": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.3.1.tgz",
+      "integrity": "sha512-wU5J8rUoo32oSef/rFpOT1HIjLjAv3qIDHkw1QIhODV3OpAVHi5oVzlouozg9obUmZKtbZ0qUe/m7FP0y0yBzA=="
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -3251,6 +3578,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+    },
+    "@types/duplexify": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.1.tgz",
+      "integrity": "sha512-n0zoEj/fMdMOvqbHxmqnza/kXyoGgJmEpsXjpP+gEqE1Ye4yNqc7xWipKnUoMpWhMuzJQSfK2gMrwlElly7OGQ==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/long": {
       "version": "4.0.2",
@@ -4216,12 +4551,12 @@
       "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "gtoken": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.1.tgz",
-      "integrity": "sha512-yqOREjzLHcbzz1UrQoxhBtpk8KjrVhuqPE7od1K2uhyxG2BHjKZetlbLw/SPZak/QqTIQW+addS+EcjqQsZbwQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
+      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
       "requires": {
         "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.0.3",
+        "google-p12-pem": "^3.1.3",
         "jws": "^4.0.0"
       }
     },
@@ -4430,6 +4765,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
     "log-driver": {
       "version": "1.2.7",
@@ -4644,6 +4984,11 @@
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
       }
+    },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
     },
     "p-limit": {
       "version": "3.1.0",

--- a/cloudrun-malware-scanner/package.json
+++ b/cloudrun-malware-scanner/package.json
@@ -15,6 +15,7 @@
     "@google-cloud/common": "^3.10.0",
     "@google-cloud/logging-bunyan": "^3.2.0",
     "@google-cloud/monitoring": "^2.3.5",
+    "@google-cloud/pubsub": "^3.0.1",
     "@google-cloud/storage": "^5.18.2",
     "@opencensus/core": "^0.1.0",
     "@opencensus/exporter-stackdriver": "^0.1.0",

--- a/cloudrun-malware-scanner/server.js
+++ b/cloudrun-malware-scanner/server.js
@@ -16,6 +16,7 @@
 
 const clamd = require('clamdjs');
 const express = require('express');
+const {PubSub} = require('@google-cloud/pubsub');
 const {Storage} = require('@google-cloud/storage');
 const {ApiError} = require('@google-cloud/common');
 const {GoogleAuth} = require('google-auth-library');
@@ -46,7 +47,7 @@ const MAX_FILE_SIZE = 500000000; // 500MiB
  *
  * Values are read from the environment variable CONFIG_FILE (which specifies a
  * JSON file to read the config from) or single-bucket config variables:
- * UNSCANNED_BUCKET, CLEAN_BUCKET and QUARANTINED_BUCKET.
+ * UPLOAD_TOPIC, UNSCANNED_BUCKET, CLEAN_BUCKET and QUARANTINED_BUCKET.
  * See {@link readAndVerifyConfig}.
  *
  * @type {{
@@ -55,11 +56,13 @@ const MAX_FILE_SIZE = 500000000; // 500MiB
  *        unscanned: string,
  *        clean: string,
  *        quarantined: string
- *       }>
+ *       }>,
+ *    upload_topic: string
  *  }}
  */
-const BUCKET_CONFIG = {
+const CONFIG = {
   buckets: [],
+  upload_topic: '',
 };
 
 // Create Clients.
@@ -67,6 +70,46 @@ const app = express();
 app.use(express.json());
 const scanner = clamd.createScanner(CLAMD_HOST, CLAMD_PORT);
 const storage = new Storage();
+
+/**
+ * Create a subscription to the upload topic.
+ *
+ * Upload topic is a Pub/Sub topic which is updated whenever a new file is
+ * uploaded to cloud storage bucket & needs to be scanned. Message format:
+ * https://cloud.google.com/storage/docs/pubsub-notifications
+ * @param {string} projectId Google Cloud Platform project ID
+ * @return {Promise<void>}
+ */
+async function subscribeToUploadTopic(
+    projectId = 'your-project-id',
+) {
+  const pubsub = new PubSub({projectId: projectId});
+
+  // Get subscriptions for upload topic, and subscribe to one
+  const [subscriptions] = await pubsub
+      .topic(CONFIG.upload_topic)
+      .getSubscriptions();
+
+  logger.info('Subscriptions on upload topic:');
+  subscriptions.forEach((sub) => console.log(sub.name));
+  const subscription = subscriptions[0];
+  logger.info('Subscribing to ' + subscription.name);
+
+  // Receive callbacks for new messages on the subscription
+  subscription.on('message', (message) => {
+    logger.info('Received message ${message.id}: ${message}');
+    onFileUpload(message);
+    message.ack();
+  });
+
+  // Receive callbacks for errors on the subscription
+  subscription.on('error', (error) => {
+    logger.error('Received error from Upload Topic:', error);
+  });
+
+  // Send a message to the topic
+  // topic.publish(Buffer.from('Test message!'));
+}
 
 /**
  * Route that is invoked by Cloud Run when a malware scan is requested
@@ -77,39 +120,34 @@ const storage = new Storage();
  * curl -d '{"kind": "storage#object","name":"sparse_file_1G", "bucket": "BUCKET_NAME" }' -H "Content-Type: application/json" http://localhost:8080
  *
  *
- * @param {!Request} req The request payload
- * @param {!Response} res The HTTP response object
+ * @param {Object} message The request payload
  */
-app.post('/', async (req, res) => {
+async function onFileUpload(message) {
   // Sanity check required values.
-  if (!req.body || req.body.kind !== 'storage#object') {
-    handleErrorResponse(res, 200, `${req.body} is not a GCS Storage Object`);
+  const file = JSON.parse(message.data);
+  if (file.kind !== 'storage#object') {
+    logger.error(`${file} is not a GCS Storage Object`);
     return;
   }
 
-  const file = req.body;
   try {
     if (!file.name) {
-      handleErrorResponse(res, 200, `file name not specified in ${file}`);
+      logger.error(`file name not specified in ${file}`);
       return;
     }
     if (!file.bucket) {
-      handleErrorResponse(res, 200, `bucket name not specified in ${file}`);
+      logger.error(`bucket name not specified in ${file}`);
       return;
     }
     if (file.size > MAX_FILE_SIZE) {
-      handleErrorResponse(
-          res, 200,
-          `file gs://${file.bucket}/${file.name} too large for scanning at ${
-            file.size} bytes`,
-          file.bucket);
+      logger.error(`file gs://${file.bucket}/${file.name} too large for scanning at ${
+        file.size} bytes`);
       return;
     }
     const config =
-        BUCKET_CONFIG.buckets.filter((c) => c.unscanned === file.bucket)[0];
+        CONFIG.buckets.filter((c) => c.unscanned === file.bucket)[0];
     if (!config) {
-      handleErrorResponse(res, 200,
-          `Bucket name - ${file.bucket} not in config`);
+      logger.error(`Bucket name - ${file.bucket} not in config`);
       return;
     }
 
@@ -117,8 +155,7 @@ app.post('/', async (req, res) => {
     // File.exists() returns a FileExistsResponse, which is a list with a
     // single value.
     if (! (await gcsFile.exists())[0]) {
-      handleErrorResponse(res, 200,
-          `File: gs://${file.bucket}/${file.name} does not exist`);
+      logger.warn(`File: gs://${file.bucket}/${file.name} does not exist. It may have already been processed.`);
       return;
     }
 
@@ -146,49 +183,24 @@ app.post('/', async (req, res) => {
       // Move document to the bucket that holds clean documents. This can
       // fail due to permissions or if the file has been deleted.
       await moveProcessedFile(file.name, true, config);
-
-      // Respond to API client.
-      res.json({status: 'clean', clam_version: clamdVersion});
     } else {
       logger.warn(`Scan status for gs://${file.bucket}/${
         file.name}: INFECTED ${result} (${
         file.size} bytes in ${scanDuration} ms)`);
-      metrics.writeScanInfected(config.unscanned, config.quarantined, file.size,
-          scanDuration, clamdVersion);
+      metrics.writeScanInfected(config.unscanned, config.quarantined,
+          file.size, scanDuration, clamdVersion);
 
       // Move document to the bucket that holds infected documents. This can
       // fail due to permissions or if the file has been deleted.
       await moveProcessedFile(file.name, false, config);
-
-      // Respond to API client.
-      res.json({
-        message: result,
-        status: 'infected',
-        result: result,
-        clam_version: clamdVersion,
-      });
     }
   } catch (e) {
     logger.error(
         {err: e},
         `Exception when processing gs://${file.bucket}/${file.name}: %s`,
         e.message);
-
-    // A 500 will cause Pubsub/EventArc to retry the event.
-    let statusCode=500;
-
-    if ((e instanceof ApiError) && [403, 404].includes(e.code) ) {
-      // Permission denied/file not found can be raised by the stream reading
-      // and by the object move. They cannot be retried, so respond
-      // with success, but log the error.
-      statusCode=200;
-    }
-
-    handleErrorResponse(res, statusCode,
-        `gs://${file.bucket}/${file.name}: ${e.message}`,
-        file.bucket);
   }
-});
+}
 
 /**
  * Trivial handler for get requests which returns the clam version.
@@ -267,7 +279,8 @@ async function readAndVerifyConfig() {
     }
     try {
       const envConfig = require(process.env.CONFIG_FILE);
-      BUCKET_CONFIG.buckets = envConfig.buckets;
+      CONFIG.buckets = envConfig.buckets;
+      CONFIG.upload_topic = envConfig.upload_topic;
     } catch (e) {
       logger.fatal(
           {err: e},
@@ -277,26 +290,32 @@ async function readAndVerifyConfig() {
         process.env.CONFIG_FILE}"`);
     }
   } else if (process.env.UNSCANNED_BUCKET && process.env.CLEAN_BUCKET &&
-      process.env.QUARANTINED_BUCKET) {
+      process.env.QUARANTINED_BUCKET && process.env.UPLOAD_TOPIC) {
+    CONFIG.upload_topic = process.env.UPLOAD_TOPIC;
+
     // Simple config for single-bucket scanning.
-    BUCKET_CONFIG.buckets = [{
+    CONFIG.buckets = [{
       unscanned: process.env.UNSCANNED_BUCKET,
       clean: process.env.CLEAN_BUCKET,
       quarantined: process.env.QUARANTINED_BUCKET,
     }];
   }
 
-  if (BUCKET_CONFIG.buckets.length === 0) {
+  if (!CONFIG.upload_topic) {
+    logger.fatal('No topic configured for uploaded files');
+    throw new Error('No topic configured');
+  }
+
+  if (CONFIG.buckets.length === 0) {
     logger.fatal(`No buckets configured for scanning`);
     throw new Error('No buckets configured');
   }
 
-  logger.info('BUCKET_CONFIG: '+JSON.stringify(BUCKET_CONFIG, null, 2));
+  logger.info('CONFIG: '+JSON.stringify(CONFIG, null, 2));
 
-  // Check buckets are specified and exist.
   let success = true;
-  for (let x = 0; x < BUCKET_CONFIG.buckets.length; x++) {
-    const config = BUCKET_CONFIG.buckets[x];
+  for (let x = 0; x < CONFIG.buckets.length; x++) {
+    const config = CONFIG.buckets[x];
     for (const bucketType of ['unscanned', 'clean', 'quarantined']) {
       const bucketName = config[bucketType];
       if (!bucketName) {
@@ -342,6 +361,7 @@ async function run() {
   }
   await metrics.init(projectId);
   await readAndVerifyConfig();
+  await subscribeToUploadTopic(projectId);
 
   app.listen(PORT, () => {
     logger.info(


### PR DESCRIPTION
The example project uses Eventarc to consume new file upload notifications, however the design calls for using Cloud Pub/Sub to make it easier to integrate with other clients.

* Added dependency on Cloud Pub/Sub library
* Added config value for new file upload topic
* Consume new file upload messages generated by Cloud Storage

https://dol-ewf.atlassian.net/browse/NVCP-311