### PR TITLE
Fix keyring issue with Google Cloud APT key

### DIFF
--- a/cloudrun-malware-scanner/Dockerfile
+++ b/cloudrun-malware-scanner/Dockerfile
@@ -44,6 +44,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         apt-transport-https \
         lsb-release \
         openssh-client \
+	gnupg \
         jq \
         gawk \
         clamav-daemon \
@@ -60,9 +61,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     echo -n "Adding Cloud SDK apt repository: " && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
         | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl -s \
-        https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-        -o /etc/apt/trusted.gpg.d/packages-cloud-google-apt.gpg && \
+    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+        | gpg --dearmor -o /etc/apt/trusted.gpg.d/packages-cloud-google-apt.gpg && \
     apt-get update -qqy && \
     apt-get install -qqy --no-install-recommends \
         google-cloud-sdk && \


### PR DESCRIPTION
ASCII  PGP key published in google clouds website needs to be converted into a keyring using gpg dearmor before being added as a PGP key. 

Fixes #46 