### PR TITLE
Update config template to support environment variables by default

### DIFF
--- a/cloudrun-malware-scanner/config.json.tmpl
+++ b/cloudrun-malware-scanner/config.json.tmpl
@@ -14,10 +14,10 @@
   ],
   "buckets": [
     {
-      "unscanned": "unscanned-bucket-name",
-      "clean": "clean-bucket-name",
-      "quarantined": "quarantined-bucket-name"
+      "unscanned": "$UNSCANNED_BUCKET_NAME",
+      "clean": "$CLEAN_BUCKET_NAME",
+      "quarantined": "$QUARANTINED_BUCKET_NAME"
     }
   ],
-  "ClamCvdMirrorBucket": "cvd-mirror-bucket-name"
+  "ClamCvdMirrorBucket": "$CVD_MIRROR_BUCKET_NAME"
 }


### PR DESCRIPTION
Environment variable support for the config was added in [v2.2.0](https://github.com/GoogleCloudPlatform/docker-clamav-malware-scanner/releases/tag/release_v2_2_0). 

Since no one has a bucket named `unscanned-bucket-name`, let's at least make these default values in `config.json.tmpl` useful. 

I propose that we update the `config.json.tmpl` file with these default env vars, as it's not entirely obvious how v2.2.0 supports this without digging into the code.

This allows automated pipelines to easily copy `config.json.tmpl` -> `config.json` without any other modifications.

Or even better yet:

- Allow the `config.json` with environment variables to be added to this repo
- Build and deploy docker container releases into the GLOBAL GCP container/artifact registry: https://console.cloud.google.com/gcr/images/google-containers/GLOBAL

That would allow users to deploy this directly from Terraform without needing to build/deploy their own localized copy.

Ref: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#image