### PR TITLE
update Dockerfile to fix cloud sdk repository change

### DIFF
--- a/cloudrun-malware-scanner/Dockerfile
+++ b/cloudrun-malware-scanner/Dockerfile
@@ -57,12 +57,11 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         clamav-base \
         clamav-daemon \
         clamav-freshclam && \
-    CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo -n "Adding Cloud SDK apt repository: " && \
-    echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" \
-        | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg \
-        | gpg --dearmor -o /etc/apt/trusted.gpg.d/packages-cloud-google-apt.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+        | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+        | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update -qqy && \
     apt-get install -qqy --no-install-recommends google-cloud-sdk && \
     gcloud config set core/disable_usage_reporting true && \


### PR DESCRIPTION
This is to fix an issue where container failed to start up due to changes to Cloud SDL apt repository.

<img width="1522" alt="Screenshot 2024-03-04 at 5 12 46 pm" src="https://github.com/GoogleCloudPlatform/docker-clamav-malware-scanner/assets/1026253/814c7c69-8baf-467c-ab61-d15f8ebf2752">