### PR TITLE
fix!: change from deprecated opencensus to opentelemetry for metrics

### DIFF
--- a/cloudrun-malware-scanner/metrics.js
+++ b/cloudrun-malware-scanner/metrics.js
@@ -14,47 +14,149 @@
 * limitations under the License.
 */
 const process = require('node:process');
+
 const {
-  globalStats,
-  MeasureUnit,
-  AggregationType,
-  TagMap,
-} = require('@opencensus/core');
-const {StackdriverStatsExporter} = require('@opencensus/exporter-stackdriver');
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} = require('@opentelemetry/sdk-metrics');
+const {Resource} = require('@opentelemetry/resources');
+const {
+  MetricExporter: GcpMetricExporter,
+} = require('@google-cloud/opentelemetry-cloud-monitoring-exporter');
+const {GcpDetectorSync} = require('@google-cloud/opentelemetry-resource-util');
+const Semconv = require('@opentelemetry/semantic-conventions');
+const {version: packageVersion} = require('./package.json');
+
 const {logger} = require('./logger.js');
 const METRIC_TYPE_ROOT = 'malware-scanning/';
+const OpenTelemetryApi = require('@opentelemetry/api');
 
-/** @typedef {import('@opencensus/core').Measure} Measure */
-
-/** @type {{[x:string]: Measure}} */
-const METRICS = {};
-
-const TAGS = {
-  sourceBucket: {name: 'source_bucket'},
-  destinationBucket: {name: 'destination_bucket'},
-  clamVersion: {name: 'clam_version'},
-  cloudRunRevision: {name: 'cloud_run_revision'},
-  cvdUpdateStatus: {name: 'cvd_update_status'},
+/**
+ * @typedef {{
+ *    [x: string]: string,
+ * }} CounterAttributes
+ */
+/** @type {CounterAttributes} */
+const RESOURCE_ATTRIBUTES = {
+  [Semconv.SEMRESATTRS_SERVICE_NAMESPACE]: 'googlecloudplatform',
+  [Semconv.SEMRESATTRS_SERVICE_NAME]: 'gcs-malware-scanning',
+  [Semconv.SEMRESATTRS_SERVICE_VERSION]: packageVersion,
 };
+
+const COUNTERS_PREFIX =
+  RESOURCE_ATTRIBUTES[Semconv.SEMRESATTRS_SERVICE_NAMESPACE] +
+  '/' +
+  RESOURCE_ATTRIBUTES[Semconv.SEMRESATTRS_SERVICE_NAME] +
+  '/';
+
+/** @enum{string} */
+const COUNTER_NAMES = {
+  cleanFiles: 'clean-files',
+  infectedFiles: 'infected-files',
+  scansFailed: 'scans-failed',
+  bytesScanned: 'bytes-scanned',
+  scanDuration: 'scan-duration',
+  cvdUpdates: 'cvd-mirror-updates',
+};
+
+const COUNTER_ATTRIBUTE_NAMES = {
+  sourceBucket: 'source_bucket',
+  destinationBucket: 'destination_bucket',
+  clamVersion: 'clam_version',
+  cloudRunRevision: 'cloud_run_revision',
+  cvdUpdateStatus: 'cvd_update_status',
+};
+
+/**
+ * Global counters object, populated by createCounters.
+ *
+ * @type {Map<
+ *    COUNTER_NAMES,
+ *    {
+ *      cumulative?: OpenTelemetryApi.Counter,
+ *      histogram?: OpenTelemetryApi.Histogram
+ *    }
+ *  >} counter Name to counter instance
+ */
+const COUNTERS = new Map();
+
 const METRIC_EXPORT_INTERVAL = parseInt(
-  process.env.EXPORT_INTERVAL || '60',
+  process.env.EXPORT_INTERVAL || '20',
   10,
 );
+
+/**
+ * Wrapper class for OpenTelemetry DiagLogger to convert to Bunyan log levels
+ *
+ * @extends {OpenTelemetryApi.DiagLogger}
+ */
+class DiagToBunyanLogger {
+  /** @constructor */
+  constructor() {
+    // In some cases where errors may be expected, we want to be able to supress
+    // them.
+    this.suppressErrors = false;
+  }
+
+  /**
+   * @param {string} message
+   * @param {any[]} args
+   */
+  verbose(message, ...args) {
+    logger.trace('otel: ' + message, args);
+  }
+
+  /**
+   * @param {string} message
+   * @param {any[]} args
+   */
+  debug(message, ...args) {
+    logger.debug('otel: ' + message, args);
+  }
+  /**
+   * @param {string} message
+   * @param {any[]} args
+   */
+  info(message, ...args) {
+    logger.info('otel: ' + message, args);
+  }
+  /**
+   * @param {string} message
+   * @param {any[]} args
+   */
+  warn(message, ...args) {
+    logger.warn('otel: ' + message, args);
+  }
+  /**
+   * @param {string} message
+   * @param {any[]} args
+   */
+  error(message, ...args) {
+    if (!this.suppressErrors) {
+      logger.error('otel: ' + message, args);
+    }
+  }
+}
+
+OpenTelemetryApi.default.diag.setLogger(new DiagToBunyanLogger(), {
+  logLevel: OpenTelemetryApi.DiagLogLevel.INFO,
+  suppressOverrideMessage: true,
+});
 
 /**
  * Writes a scan failed metric.
  * @param {string?} sourceBucket
  */
 function writeScanFailedMetric(sourceBucket) {
-  const tags = new TagMap();
+  const attrs = {
+    [COUNTER_ATTRIBUTE_NAMES.cloudRunRevision]:
+      process.env.K_REVISION || 'no-revision',
+  };
   if (sourceBucket) {
-    tags.set(TAGS.sourceBucket, {value: sourceBucket});
-    tags.set(TAGS.destinationBucket, {value: sourceBucket});
+    attrs[COUNTER_ATTRIBUTE_NAMES.sourceBucket] = sourceBucket;
+    attrs[COUNTER_ATTRIBUTE_NAMES.destinationBucket] = sourceBucket;
   }
-  tags.set(TAGS.cloudRunRevision, {
-    value: process.env.K_REVISION || 'no-revision',
-  });
-  globalStats.record([{measure: METRICS.scansFailed, value: 1}], tags);
+  COUNTERS.get(COUNTER_NAMES.scansFailed)?.cumulative?.add(1, attrs);
 }
 
 /**
@@ -73,7 +175,7 @@ function writeScanCleanMetric(
   clamVersion,
 ) {
   writeScanCompletedMetric_(
-    METRICS.cleanFiles,
+    COUNTER_NAMES.cleanFiles,
     sourceBucket,
     destinationBucket,
     fileSize,
@@ -98,7 +200,7 @@ function writeScanInfectedMetric(
   clamVersion,
 ) {
   writeScanCompletedMetric_(
-    METRICS.infectedFiles,
+    COUNTER_NAMES.infectedFiles,
     sourceBucket,
     destinationBucket,
     fileSize,
@@ -109,7 +211,7 @@ function writeScanInfectedMetric(
 /**
  * Writes metrics for completed scans
  * @private
- * @param {!Measure} measure
+ * @param {string} counterName
  * @param {string} sourceBucket
  * @param {string} destinationBucket
  * @param {number} fileSize
@@ -117,27 +219,31 @@ function writeScanInfectedMetric(
  * @param {string} clamVersion
  */
 function writeScanCompletedMetric_(
-  measure,
+  counterName,
   sourceBucket,
   destinationBucket,
   fileSize,
   scanDuration,
   clamVersion,
 ) {
-  const tags = new TagMap();
-  tags.set(TAGS.sourceBucket, {value: sourceBucket});
-  tags.set(TAGS.destinationBucket, {value: destinationBucket});
-  tags.set(TAGS.clamVersion, {value: clamVersion});
-  tags.set(TAGS.cloudRunRevision, {
-    value: process.env.K_REVISION || 'no-revision',
-  });
-  globalStats.record(
-    [
-      {measure: measure, value: 1},
-      {measure: METRICS.bytesScanned, value: fileSize},
-      {measure: METRICS.scanDuration, value: scanDuration},
-    ],
-    tags,
+  const attrs = {
+    [COUNTER_ATTRIBUTE_NAMES.sourceBucket]: sourceBucket,
+    [COUNTER_ATTRIBUTE_NAMES.destinationBucket]: destinationBucket,
+    [COUNTER_ATTRIBUTE_NAMES.clamVersion]: clamVersion,
+    [COUNTER_ATTRIBUTE_NAMES.cloudRunRevision]:
+      process.env.K_REVISION || 'no-revision',
+  };
+
+  const counter = COUNTERS.get(counterName);
+  if (!counter?.cumulative) {
+    throw new Error('Unknown counter: ' + counterName);
+  }
+  counter.cumulative.add(1, attrs);
+
+  COUNTERS.get('bytes-scanned')?.cumulative?.add(fileSize, attrs);
+  COUNTERS.get(COUNTER_NAMES.scanDuration)?.histogram?.record(
+    scanDuration,
+    attrs,
   );
 }
 
@@ -148,18 +254,15 @@ function writeScanCompletedMetric_(
  * @param {boolean} isUpdated
  */
 function writeCvdMirrorUpdatedMetric(success, isUpdated) {
-  const tags = new TagMap();
-  tags.set(TAGS.cloudRunRevision, {
-    value: process.env.K_REVISION || 'no-revision',
-  });
-  tags.set(TAGS.cvdUpdateStatus, {
-    value: success
+  COUNTERS.get(COUNTER_NAMES.cvdUpdates)?.cumulative?.add(1, {
+    [COUNTER_ATTRIBUTE_NAMES.cloudRunRevision]:
+      process.env.K_REVISION || 'no-revision',
+    [COUNTER_ATTRIBUTE_NAMES.cvdUpdateStatus]: success
       ? isUpdated
         ? 'SUCCESS_UPDATED'
         : 'SUCCESS_NO_UPDATES'
       : 'FAILURE',
   });
-  globalStats.record([{measure: METRICS.cvdUpdates, value: 1}], tags);
 }
 
 /**
@@ -171,114 +274,86 @@ async function initMetrics(projectId) {
     throw Error('Unable to proceed without a Project ID');
   }
 
-  const exporter = new StackdriverStatsExporter({
-    projectId: projectId,
-    period: METRIC_EXPORT_INTERVAL * 1000,
-  });
-  globalStats.registerExporter(exporter);
+  logger.debug('initializing metrics');
 
-  const fileScanTags = [
-    TAGS.clamVersion,
-    TAGS.cloudRunRevision,
-    TAGS.sourceBucket,
-    TAGS.destinationBucket,
-  ];
+  const resources = new GcpDetectorSync()
+    .detect()
+    .merge(new Resource(RESOURCE_ATTRIBUTES));
 
-  METRICS.cleanFiles = globalStats.createMeasureInt64(
-    METRIC_TYPE_ROOT + 'clean-files',
-    MeasureUnit.UNIT,
-    'Number of clean files processed',
-  );
-
-  const cleanFilesView = globalStats.createView(
-    METRICS.cleanFiles.name,
-    METRICS.cleanFiles,
-    AggregationType.COUNT,
-    fileScanTags,
-    'Number of files scanned that were found ' +
-      'to be clean of malware at the time of scan',
-  );
-  globalStats.registerView(cleanFilesView);
-
-  METRICS.infectedFiles = globalStats.createMeasureInt64(
-    METRIC_TYPE_ROOT + 'infected-files',
-    MeasureUnit.UNIT,
-    'Number of infected files processed',
-  );
-
-  const infectedFilesView = globalStats.createView(
-    METRICS.infectedFiles.name,
-    METRICS.infectedFiles,
-    AggregationType.COUNT,
-    fileScanTags,
-    'Number of files scanned that were found ' +
-      'to contain malware at the time of scan',
-  );
-  globalStats.registerView(infectedFilesView);
-
-  METRICS.scansFailed = globalStats.createMeasureInt64(
-    METRIC_TYPE_ROOT + 'scans-failed',
-    MeasureUnit.UNIT,
-    'Number of failed scan requests',
-  );
-
-  const failedScansView = globalStats.createView(
-    METRICS.scansFailed.name,
-    METRICS.scansFailed,
-    AggregationType.COUNT,
-    fileScanTags,
-    'Number of malware scan requests which failed',
-  );
-  globalStats.registerView(failedScansView);
-
-  METRICS.bytesScanned = globalStats.createMeasureInt64(
-    METRIC_TYPE_ROOT + 'bytes-scanned',
-    MeasureUnit.BYTE,
-    'Number of bytes processed',
-  );
-
-  const bytesScannedView = globalStats.createView(
-    METRICS.bytesScanned.name,
-    METRICS.bytesScanned,
-    AggregationType.SUM,
-    fileScanTags,
-    'Total number of bytes scanned',
-  );
-  globalStats.registerView(bytesScannedView);
-
-  METRICS.scanDuration = globalStats.createMeasureDouble(
-    METRIC_TYPE_ROOT + 'scan-duration',
-    MeasureUnit.MS,
-    'The scan duration in milliseconds',
-  );
-  const scanDurationView = globalStats.createView(
-    METRICS.scanDuration.name,
-    METRICS.scanDuration,
-    AggregationType.DISTRIBUTION,
-    fileScanTags,
-    'Duration spent scanning files',
-    // Bucket Boundaries in ms
-    [
-      0, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000,
-      200000,
+  const meterProvider = new MeterProvider({
+    resource: resources,
+    readers: [
+      new PeriodicExportingMetricReader({
+        exportIntervalMillis: METRIC_EXPORT_INTERVAL,
+        exportTimeoutMillis: METRIC_EXPORT_INTERVAL,
+        exporter: new GcpMetricExporter({prefix: 'workload.googleapis.com'}),
+      }),
     ],
-  );
-  globalStats.registerView(scanDurationView);
+  });
 
-  METRICS.cvdUpdates = globalStats.createMeasureInt64(
-    METRIC_TYPE_ROOT + 'cvd-mirror-updates',
-    MeasureUnit.UNIT,
-    'Number of CVD mirror Update Checks performed',
-  );
+  const meter = meterProvider.getMeter(COUNTERS_PREFIX);
 
-  const cvdUpdatesView = globalStats.createView(
-    METRICS.cvdUpdates.name,
-    METRICS.cvdUpdates,
-    AggregationType.COUNT,
-    [TAGS.cloudRunRevision, TAGS.cvdUpdateStatus],
-    'Number of CVD mirror update checks performed with their status',
-  );
-  globalStats.registerView(cvdUpdatesView);
+  COUNTERS.set(COUNTER_NAMES.cleanFiles, {
+    cumulative: meter.createCounter(
+      COUNTERS_PREFIX + COUNTER_NAMES.cleanFiles,
+      {
+        description:
+          'Number of files scanned that were found to be clean of malware at the time of scan',
+      },
+    ),
+  });
+
+  COUNTERS.set(COUNTER_NAMES.infectedFiles, {
+    cumulative: meter.createCounter(
+      COUNTERS_PREFIX + COUNTER_NAMES.infectedFiles,
+      {
+        description:
+          'Number of files scanned that were found to contain malware at the time of scan',
+      },
+    ),
+  });
+
+  COUNTERS.set(COUNTER_NAMES.scansFailed, {
+    cumulative: meter.createCounter(
+      COUNTERS_PREFIX + COUNTER_NAMES.scansFailed,
+      {
+        description: 'Number of malware scan requests which failed',
+      },
+    ),
+  });
+
+  COUNTERS.set(COUNTER_NAMES.bytesScanned, {
+    cumulative: meter.createCounter(COUNTERS_PREFIX + 'bytes-scanned', {
+      description: 'Total number of bytes scanned',
+      unit: 'By',
+    }),
+  });
+
+  COUNTERS.set(COUNTER_NAMES.scanDuration, {
+    histogram: meter.createHistogram(
+      COUNTERS_PREFIX + COUNTER_NAMES.scanDuration,
+      {
+        description: 'Duration spent scanning files',
+        unit: 'ms',
+        advice: {
+          explicitBucketBoundaries: [
+            0, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000,
+            200000,
+          ],
+        },
+      },
+    ),
+  });
+
+  COUNTERS.set(COUNTER_NAMES.cvdUpdates, {
+    cumulative: meter.createCounter(
+      COUNTERS_PREFIX + COUNTER_NAMES.cvdUpdates,
+      {
+        description:
+          'Number of CVD mirror update checks performed with their status',
+      },
+    ),
+  });
 
   logger.info(
     `Metrics initialized for ${METRIC_TYPE_ROOT} on project ${projectId}`,

--- a/cloudrun-malware-scanner/package-lock.json
+++ b/cloudrun-malware-scanner/package-lock.json
@@ -9,9 +9,11 @@
       "version": "2.6.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.19.0",
+        "@google-cloud/opentelemetry-resource-util": "^2.3.0",
         "@google-cloud/storage": "^7.12.0",
-        "@opencensus/core": "^0.1.0",
-        "@opencensus/exporter-stackdriver": "^0.1.0",
+        "@opentelemetry/sdk-metrics": "^1.25.1",
+        "@opentelemetry/semantic-conventions": "^1.25.1",
         "clamdjs": "^1.0.2",
         "eventid": "^2.0.1",
         "express": "^4.19.2",
@@ -489,6 +491,41 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@google-cloud/opentelemetry-cloud-monitoring-exporter": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-cloud-monitoring-exporter/-/opentelemetry-cloud-monitoring-exporter-0.19.0.tgz",
+      "integrity": "sha512-5SOPXwC6RET4ZvXxw5D97dp8fWpqWEunHrzrUUGXhG4UAeedQe1KvYV8CK+fnaAbN2l2ha6QDYspT6z40TVY0g==",
+      "dependencies": {
+        "@google-cloud/opentelemetry-resource-util": "^2.3.0",
+        "@google-cloud/precise-date": "^4.0.0",
+        "google-auth-library": "^9.0.0",
+        "googleapis": "^137.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/resources": "^1.0.0",
+        "@opentelemetry/sdk-metrics": "^1.0.0"
+      }
+    },
+    "node_modules/@google-cloud/opentelemetry-resource-util": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/opentelemetry-resource-util/-/opentelemetry-resource-util-2.3.0.tgz",
+      "integrity": "sha512-3yyG2IiOWXy23IIGW4rRaqVf0efsgkUyXLvDpCxiZPPIgSAevYVdfcJ2cQSp4d1y+2NCpS2Wq0XLbTLzTw/j5Q==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.22.0",
+        "gcp-metadata": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/resources": "^1.0.0"
+      }
+    },
     "node_modules/@google-cloud/paginator": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
@@ -497,6 +534,14 @@
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/precise-date": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-4.0.0.tgz",
+      "integrity": "sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -604,126 +649,66 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@opencensus/core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.1.0.tgz",
-      "integrity": "sha512-Bdbi5vi44a1fwyHNyKh6bwzuFZJeZJPhzdwogk/Kw5juoEeRGPworK1sgtB3loeR8cqLyi5us0mz9h0xqINiSQ==",
-      "dependencies": {
-        "continuation-local-storage": "^3.2.1",
-        "log-driver": "^1.2.7",
-        "semver": "^7.0.0",
-        "shimmer": "^1.2.0",
-        "uuid": "^8.0.0"
-      },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=8.0.0"
       }
     },
-    "node_modules/@opencensus/exporter-stackdriver": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@opencensus/exporter-stackdriver/-/exporter-stackdriver-0.1.0.tgz",
-      "integrity": "sha512-MsvA7lvGyKMcZjDl91nn82lyh/HUUW12UxiGjrXqFYbP1ZMav996s2Cqwi1ir2uUSA559hIPMDXezoBwyA130A==",
+    "node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
       "dependencies": {
-        "@opencensus/core": "^0.1.0",
-        "@opencensus/resource-util": "^0.1.0",
-        "google-auth-library": "^6.1.6",
-        "googleapis": "67.0.0"
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opencensus/exporter-stackdriver/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
       "dependencies": {
-        "debug": "4"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opencensus/exporter-stackdriver/node_modules/gaxios": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
       "dependencies": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.7"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opencensus/exporter-stackdriver/node_modules/google-auth-library": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
-      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
-      "dependencies": {
-        "arrify": "^2.0.0",
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
-      },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@opencensus/exporter-stackdriver/node_modules/gtoken": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
-      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
-      "dependencies": {
-        "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@opencensus/exporter-stackdriver/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@opencensus/exporter-stackdriver/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@opencensus/resource-util": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@opencensus/resource-util/-/resource-util-0.1.0.tgz",
-      "integrity": "sha512-YO6N7OYZJGpvnthn5zUwIpwlg29o2dL1xWXo6liHWD6dtEPzYN5gKVz7zArwfG0qhgPucdexYH15UulUrJV31g==",
-      "dependencies": {
-        "@opencensus/core": "^0.1.0",
-        "gcp-metadata": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -990,26 +975,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/async-listener": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "dependencies": {
-        "semver": "^5.3.0",
-        "shimmer": "^1.1.0"
-      },
-      "engines": {
-        "node": "<=0.11.8 || >0.11.10"
-      }
-    },
-    "node_modules/async-listener/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -1268,15 +1233,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/continuation-local-storage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "dependencies": {
-        "async-listener": "^0.6.0",
-        "emitter-listener": "^1.1.1"
-      }
-    },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
@@ -1499,14 +1455,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
-    },
-    "node_modules/emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "dependencies": {
-        "shimmer": "^1.2.0"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2005,11 +1953,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/fast-text-encoding": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="
-    },
     "node_modules/fast-xml-parser": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
@@ -2213,64 +2156,15 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
-      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
       "dependencies": {
-        "gaxios": "^4.0.0",
+        "gaxios": "^6.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/gaxios": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.7"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/gcp-metadata/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=14"
       }
     },
     "node_modules/get-caller-file": {
@@ -2385,221 +2279,44 @@
         "node": ">=14"
       }
     },
-    "node_modules/google-auth-library/node_modules/gcp-metadata": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
-      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/google-p12-pem": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
-      "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
-      "dependencies": {
-        "node-forge": "^1.3.1"
-      },
-      "bin": {
-        "gp12-pem": "build/src/bin/gp12-pem.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/googleapis": {
-      "version": "67.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-67.0.0.tgz",
-      "integrity": "sha512-luhulHrk42DruR+c12W2sY2rrEVoKVdjaZDuHWSxcp1qz+VxvWQpuiK2QDLCXmo36/VFPMaa+Y7rRUR+Qqzd7w==",
+      "version": "137.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-137.1.0.tgz",
+      "integrity": "sha512-2L7SzN0FLHyQtFmyIxrcXhgust77067pkkduqkbIpDuj9JzVnByxsRrcRfUMFQam3rQkWW2B0f1i40IwKDWIVQ==",
       "dependencies": {
-        "google-auth-library": "^6.0.0",
-        "googleapis-common": "^4.4.1"
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/googleapis-common": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-4.4.3.tgz",
-      "integrity": "sha512-W46WKCk3QtlCCfmZyQIH5zxmDOyeV5Qj+qs7nr2ox08eRkEJMWp6iwv542R/PsokXaGUSrmif4vCC4+rGzRSsQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
       "dependencies": {
         "extend": "^3.0.2",
-        "gaxios": "^4.0.0",
-        "google-auth-library": "^6.0.0",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
         "qs": "^6.7.0",
         "url-template": "^2.0.8",
-        "uuid": "^8.0.0"
+        "uuid": "^9.0.0"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/googleapis-common/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/googleapis-common/node_modules/gaxios": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.7"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/googleapis-common/node_modules/google-auth-library": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
-      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
-      "dependencies": {
-        "arrify": "^2.0.0",
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/googleapis-common/node_modules/gtoken": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
-      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
-      "dependencies": {
-        "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/googleapis-common/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/googleapis-common/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/googleapis/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/googleapis/node_modules/gaxios": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.7"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/googleapis/node_modules/google-auth-library": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
-      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
-      "dependencies": {
-        "arrify": "^2.0.0",
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "fast-text-encoding": "^1.0.0",
-        "gaxios": "^4.0.0",
-        "gcp-metadata": "^4.2.0",
-        "gtoken": "^5.0.4",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/googleapis/node_modules/gtoken": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
-      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
-      "dependencies": {
-        "gaxios": "^4.0.0",
-        "google-p12-pem": "^3.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/googleapis/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/googleapis/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gopd": {
@@ -3137,8 +2854,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
@@ -3169,25 +2885,6 @@
       "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
       "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
-    },
-    "node_modules/log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-      "engines": {
-        "node": ">=0.8.6"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -3327,14 +3024,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
-      "engines": {
-        "node": ">= 6.13.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -3869,6 +3558,7 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3983,11 +3673,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "node_modules/side-channel": {
       "version": "1.0.6",
@@ -4404,11 +4089,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/cloudrun-malware-scanner/package.json
+++ b/cloudrun-malware-scanner/package.json
@@ -17,9 +17,11 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "dependencies": {
+    "@google-cloud/opentelemetry-cloud-monitoring-exporter": "^0.19.0",
+    "@google-cloud/opentelemetry-resource-util": "^2.3.0",
     "@google-cloud/storage": "^7.12.0",
-    "@opencensus/core": "^0.1.0",
-    "@opencensus/exporter-stackdriver": "^0.1.0",
+    "@opentelemetry/sdk-metrics": "^1.25.1",
+    "@opentelemetry/semantic-conventions": "^1.25.1",
     "clamdjs": "^1.0.2",
     "eventid": "^2.0.1",
     "express": "^4.19.2",


### PR DESCRIPTION
BREAKING CHANGE: metric names have changed from
`custom.googleapis.com/opencensus/malware-scanning/METRIC-NAME` to
`workload.googleapis.com/googlecloudplatform/gcs-malware-scanning/METRIC-NAME`