### PR TITLE
fix(scanner): Do not move the file, just let it be

### DIFF
--- a/cloudrun-malware-scanner/config.ts
+++ b/cloudrun-malware-scanner/config.ts
@@ -25,7 +25,6 @@ import {Storage} from '@google-cloud/storage';
  */
 export type BucketDefs = {
   unscanned: string;
-  clean: string;
   quarantined: string;
 };
 
@@ -38,9 +37,7 @@ export type Config = {
   comments?: string | string[];
 };
 
-const BUCKET_TYPES = ['unscanned', 'clean', 'quarantined'] as Array<
-  keyof BucketDefs
->;
+const BUCKET_TYPES = ['unscanned', 'quarantined'] as Array<keyof BucketDefs>;
 
 /**
  * Read configuration from JSON configuration file, parse, verify
@@ -105,11 +102,7 @@ async function validateConfig(config: any, storage: Storage): Promise<Config> {
         success = false;
       }
     }
-    if (
-      bucketDefs.unscanned === bucketDefs.clean ||
-      bucketDefs.unscanned === bucketDefs.quarantined ||
-      bucketDefs.clean === bucketDefs.quarantined
-    ) {
+    if (bucketDefs.unscanned === bucketDefs.quarantined) {
       logger.fatal(
         `Config Error: buckets[${x.toString()}]: bucket names are not unique`,
       );

--- a/cloudrun-malware-scanner/scanner.ts
+++ b/cloudrun-malware-scanner/scanner.ts
@@ -135,7 +135,7 @@ export class Scanner {
         );
         this.metricsClient.writeScanIgnored(
           bucketDefs.unscanned,
-          bucketDefs.clean,
+          bucketDefs.unscanned,
           fileSize,
           'ZERO_LENGTH_FILE',
         );
@@ -149,7 +149,7 @@ export class Scanner {
         );
         this.metricsClient.writeScanIgnored(
           bucketDefs.unscanned,
-          bucketDefs.clean,
+          bucketDefs.unscanned,
           fileSize,
           'FILE_TOO_LARGE',
         );
@@ -164,7 +164,7 @@ export class Scanner {
           );
           this.metricsClient.writeScanIgnored(
             bucketDefs.unscanned,
-            bucketDefs.clean,
+            bucketDefs.unscanned,
             fileSize,
             'REGEXP_MATCH',
             regexp.toString(),
@@ -196,7 +196,7 @@ export class Scanner {
         );
         this.metricsClient.writeScanIgnored(
           bucketDefs.unscanned,
-          bucketDefs.clean,
+          bucketDefs.unscanned,
           fileSize,
           'FILE_SIZE_MISMATCH',
         );
@@ -225,13 +225,11 @@ export class Scanner {
         );
         this.metricsClient.writeScanClean(
           bucketDefs.unscanned,
-          bucketDefs.clean,
+          bucketDefs.unscanned,
           fileSize,
           scanDuration,
           clamdVersion,
         );
-
-        await this.moveProcessedFile(gcsFile, bucketDefs.clean);
 
         return {
           status: 'clean',

--- a/cloudrun-malware-scanner/spec/config.spec.ts
+++ b/cloudrun-malware-scanner/spec/config.spec.ts
@@ -22,7 +22,6 @@ const GOOD_CONFIG: Config.Config = {
     {
       unscanned: 'unscannedBucket',
       quarantined: 'quarantinedBucket',
-      clean: 'cleanBucket',
     },
   ],
   ClamCvdMirrorBucket: 'csvMirrorBucket',
@@ -79,7 +78,7 @@ describe('Config', () => {
       );
       expect(config).toEqual(GOOD_CONFIG);
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(existingBucket.getFiles as jasmine.Spy).toHaveBeenCalledTimes(4);
+      expect(existingBucket.getFiles as jasmine.Spy).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -162,12 +161,7 @@ describe('Config', () => {
       ).toBeRejectedWithError('Invalid configuration');
 
       config.ClamCvdMirrorBucket = GOOD_CONFIG.ClamCvdMirrorBucket;
-      config.buckets[0].clean = 'nonExistingBucket';
-      await expectAsync(
-        Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
-      ).toBeRejectedWithError('Invalid configuration');
 
-      config.buckets[0].clean = GOOD_CONFIG.buckets[0].clean;
       config.buckets[0].unscanned = 'nonExistingBucket';
       await expectAsync(
         Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
@@ -175,27 +169,6 @@ describe('Config', () => {
 
       config.buckets[0].unscanned = GOOD_CONFIG.buckets[0].unscanned;
       config.buckets[0].quarantined = 'nonExistingBucket';
-      await expectAsync(
-        Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
-      ).toBeRejectedWithError('Invalid configuration');
-    });
-
-    it('identical buckets in same group trigger failure', async () => {
-      const config = structuredClone(GOOD_CONFIG);
-
-      config.buckets[0].quarantined = GOOD_CONFIG.buckets[0].unscanned;
-      await expectAsync(
-        Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
-      ).toBeRejectedWithError('Invalid configuration');
-
-      config.buckets[0].quarantined = GOOD_CONFIG.buckets[0].quarantined;
-      config.buckets[0].clean = GOOD_CONFIG.buckets[0].unscanned;
-      await expectAsync(
-        Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
-      ).toBeRejectedWithError('Invalid configuration');
-
-      config.buckets[0].clean = GOOD_CONFIG.buckets[0].clean;
-      config.buckets[0].quarantined = GOOD_CONFIG.buckets[0].clean;
       await expectAsync(
         Config.TEST_ONLY.validateConfig(config, storageServiceSpy),
       ).toBeRejectedWithError('Invalid configuration');

--- a/cloudrun-malware-scanner/spec/scanner.spec.ts
+++ b/cloudrun-malware-scanner/spec/scanner.spec.ts
@@ -26,7 +26,6 @@ const CONFIG: Config = {
     {
       unscanned: 'unscannedBucket',
       quarantined: 'quarantinedBucket',
-      clean: 'cleanBucket',
     },
   ],
   ClamCvdMirrorBucket: 'csvMirrorBucket',
@@ -43,7 +42,6 @@ describe('Scanner', () => {
   let metricsClient: jasmine.SpyObj<typeof metrics>;
   let storageClient: jasmine.SpyObj<gcs.Storage>;
   let mockUnscannedBucket: jasmine.SpyObj<gcs.Bucket>;
-  let mockCleanBucket: jasmine.SpyObj<gcs.Bucket>;
   let mockQuarantinedBucket: jasmine.SpyObj<gcs.Bucket>;
   let mockFile: jasmine.SpyObj<gcs.File>;
 
@@ -84,17 +82,6 @@ describe('Scanner', () => {
       .withArgs('unscannedBucket')
       .and.returnValue(mockUnscannedBucket);
 
-    mockCleanBucket = jasmine.createSpyObj<gcs.Bucket>(
-      'cleanBucket',
-      ['file'],
-      {
-        name: 'cleanBucket',
-      },
-    );
-    storageClient.bucket
-      .withArgs('cleanBucket')
-      .and.returnValue(mockCleanBucket);
-
     mockQuarantinedBucket = jasmine.createSpyObj<gcs.Bucket>(
       'quarantinedBucket',
       ['file'],
@@ -110,7 +97,7 @@ describe('Scanner', () => {
       {
         name: TEST_FILE_NAME,
         cloudStorageURI: new URL(
-          `gs://${CONFIG.buckets[0].clean}/${TEST_FILE_NAME}`,
+          `gs://${CONFIG.buckets[0].unscanned}/${TEST_FILE_NAME}`,
         ),
       },
     );
@@ -185,7 +172,7 @@ describe('Scanner', () => {
       });
       expect(metricsClient.writeScanIgnored).toHaveBeenCalledWith(
         CONFIG.buckets[0].unscanned,
-        CONFIG.buckets[0].clean,
+        CONFIG.buckets[0].unscanned,
         0,
         'ZERO_LENGTH_FILE',
       );
@@ -203,7 +190,7 @@ describe('Scanner', () => {
       });
       expect(metricsClient.writeScanIgnored).toHaveBeenCalledWith(
         CONFIG.buckets[0].unscanned,
-        CONFIG.buckets[0].clean,
+        CONFIG.buckets[0].unscanned,
         request.size,
         'FILE_TOO_LARGE',
       );
@@ -229,14 +216,14 @@ describe('Scanner', () => {
 
       expect(metricsClient.writeScanIgnored).toHaveBeenCalledWith(
         CONFIG.buckets[0].unscanned,
-        CONFIG.buckets[0].clean,
+        CONFIG.buckets[0].unscanned,
         100,
         'REGEXP_MATCH',
         '/\\.tmp$/',
       );
       expect(metricsClient.writeScanIgnored).toHaveBeenCalledWith(
         CONFIG.buckets[0].unscanned,
-        CONFIG.buckets[0].clean,
+        CONFIG.buckets[0].unscanned,
         100,
         'REGEXP_MATCH',
         '/\\.multipart\\./i',
@@ -275,7 +262,7 @@ describe('Scanner', () => {
       });
       expect(metricsClient.writeScanIgnored).toHaveBeenCalledWith(
         CONFIG.buckets[0].unscanned,
-        CONFIG.buckets[0].clean,
+        CONFIG.buckets[0].unscanned,
         100,
         'FILE_SIZE_MISMATCH',
       );
@@ -345,11 +332,11 @@ describe('Scanner', () => {
         // eslint-disable-next-line @typescript-eslint/unbound-method
         expect(mockReadStream.destroy).toHaveBeenCalled();
         // .toHaveBeenCalledWith does not work due to overloading of func.
-        expect(mockFile.move.calls.count()).toBe(1);
-        expect(mockFile.move.calls.first().args[0]).toBe(mockCleanBucket);
+        // we're not moving it now
+        expect(mockFile.move.calls.count()).toBe(0);
         expect(metricsClient.writeScanClean).toHaveBeenCalledWith(
           CONFIG.buckets[0].unscanned,
-          CONFIG.buckets[0].clean,
+          CONFIG.buckets[0].unscanned,
           100,
           0,
           CLAMD_VERSION_STRING,

--- a/cloudrun-malware-scanner/spec/support/good-config.json
+++ b/cloudrun-malware-scanner/spec/support/good-config.json
@@ -3,8 +3,7 @@
   "buckets": [
     {
       "unscanned": "unscannedBucket",
-      "quarantined": "quarantinedBucket",
-      "clean": "cleanBucket"
+      "quarantined": "quarantinedBucket"
     }
   ],
   "ClamCvdMirrorBucket": "csvMirrorBucket"


### PR DESCRIPTION
The original of this has the concept of an unscanned, clean and quarantine bucket. The file lands in unscanned, then gets moved to clean or quarantine. We can't make that big of a change to our current structure right now. Instead, let's have it scan the unscanned bucket and move things to quarantine if they pop positive.

I verified this in dev yesterday (see [slack](https://promisehq.slack.com/archives/C070934KJJX/p1741469996194729))